### PR TITLE
fix: respond with res.json when no client

### DIFF
--- a/pages/api/collections.js
+++ b/pages/api/collections.js
@@ -13,7 +13,7 @@ export default async (req, res) => {
     let collections = [];
 
     if (!client) {
-      return [];
+      return res.json({ collections: [] });
     }
 
     await client

--- a/pages/api/collections.js
+++ b/pages/api/collections.js
@@ -13,7 +13,7 @@ export default async (req, res) => {
     let collections = [];
 
     if (!client) {
-      return res.json({ collections: [] });
+      return res.status(500).json({ error: new Error('Missing secret to connect to FaunaDB') });
     }
 
     await client


### PR DESCRIPTION
I noticed the server hanged when using this example.

I don't think this is the right thing, it would be better to retrieve the error of why the connection failed and send that back but I'm only starting and don't know how to do that!

In my case, I misconfigured env variables, so the error could be that